### PR TITLE
Bump symfony max version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">=2.2,<2.4-dev",
+        "symfony/symfony": "~2.2",
         "sonata-project/media-bundle": "2.2.*@dev"
     },
     "suggest": {


### PR DESCRIPTION
Symfony should maintain backwards compatible from 2.3 and up and is using semver, so the maximum version can be bumped up

Fixes #8
