### PR TITLE
Missing check if provider key in persistent_parameters array is set in MediaAdmin:browser.html.twig

### DIFF
--- a/Resources/views/MediaAdmin/browser.html.twig
+++ b/Resources/views/MediaAdmin/browser.html.twig
@@ -44,14 +44,14 @@
                 {% if providers|length > 1 %}
                     <li><a><strong>{{ "label.select_provider"|trans({}, 'SonataMediaBundle') }}</strong></a></li>
 
-                    {% if not persistent_parameters.provider %}
+                    {% if (persistent_parameters.provider is not defined) or (not persistent_parameters.provider) %}
                         <li class="active"><a href="{{ admin.generateUrl('browser', {'context': persistent_parameters.context, 'provider': null}|merge(ckParameters)) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
                     {% else %}
                         <li><a href="{{ admin.generateUrl('browser', {'context': persistent_parameters.context, 'provider': null}|merge(ckParameters)) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
                     {% endif %}
 
                     {% for provider_name in providers %}
-                        {% if persistent_parameters.provider == provider_name%}
+                        {% if (persistent_parameters.provider is defined) and (persistent_parameters.provider == provider_name) %}
                             <li class="active"><a href="{{ admin.generateUrl('browser', {'context': persistent_parameters.context, 'provider': provider_name}|merge(ckParameters)) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
                         {% else %}
                             <li><a href="{{ admin.generateUrl('browser', {'context': persistent_parameters.context, 'provider': provider_name}|merge(ckParameters)) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>


### PR DESCRIPTION
sonata-media: ^3.0
> Key "provider" for array with keys "context, category, hide_context" does not exist

https://github.com/sonata-project/SonataMediaBundle/blob/3.0.0/Admin/BaseMediaAdmin.php#L93

issue https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle/issues/17