### PR TITLE
MediaAdminController compatibility with Symfony 3.4

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -127,7 +127,14 @@ class MediaAdminController extends BaseMediaAdminController
                 ->renderer->setTheme($formView, $theme);
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+        
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
+            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+            return;
+        }
+
+        $twig->getRuntime('Symfony\Component\Form\FormRenderer')->setTheme($formView, $theme);
     }
 
 }


### PR DESCRIPTION
[Use FormRenderer runtime to maintain compatibility with Symfony 3.4](https://github.com/sonata-project/SonataMediaBundle/pull/1325)

Symfony 3.4 deprecates TwigRenderer (TwigBridge) in favour of FormRenderer (Form component). While the old class is still available, it is not registered as a Twig runtime anymore. [(See this related changeset in the TwigBridge component.)](https://github.com/symfony/symfony/pull/23437/files#diff-5eb0532c96734f6e23428e921225b2f0)