### PR TITLE
Add Compatibility for Symfony 4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,9 +36,9 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('templates')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('layout')->defaultValue('CoopTilleulsCKEditorSonataMediaBundle::layout.html.twig')->cannotBeEmpty()->end()
-                        ->scalarNode('browser')->defaultValue('CoopTilleulsCKEditorSonataMediaBundle:MediaAdmin:browser.html.twig')->cannotBeEmpty()->end()
-                        ->scalarNode('upload')->defaultValue('CoopTilleulsCKEditorSonataMediaBundle:MediaAdmin:upload.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('layout')->defaultValue('@CoopTilleulsCKEditorSonataMedia/layout.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('browser')->defaultValue('@CoopTilleulsCKEditorSonataMedia/MediaAdmin/browser.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('upload')->defaultValue('@CoopTilleulsCKEditorSonataMedia/MediaAdmin/upload.html.twig')->cannotBeEmpty()->end()
                     ->end()
             ->end()
         ;

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="coop_tilleuls_ck_editor_sonata_media.media.extension.class">CoopTilleuls\Bundle\CKEditorSonataMediaBundle\Admin\MediaAdminExtension</parameter>
+        <parameter key="sonata.media.admin.media.controller">CoopTilleuls\Bundle\CKEditorSonataMediaBundle\Controller\MediaAdminController</parameter>
     </parameters>
 
     <services>

--- a/Resources/doc/install.md
+++ b/Resources/doc/install.md
@@ -2,9 +2,13 @@
 
 If not already done, install and configure [SonataMediaBundle](http://sonata-project.org/bundles/media/master/doc/index.html).
 
-Then, use [Composer](https://getcomposer.org/) to install CoopTilleulsCKEditorSonataMediaBundle and IvoryCKEditorBundle:
+Then, use [Composer](https://getcomposer.org/) to install CoopTilleulsCKEditorSonataMediaBundle and FOSCKEditorBundle:
 
-    composer require tilleuls/ckeditor-sonata-media-bundle egeloen/ckeditor-bundle
+    composer require tilleuls/ckeditor-sonata-media-bundle friendsofsymfony/ckeditor-bundle
+
+If you use Symfony <3.4 and PHP <7.1 do
+
+    composer require tilleuls/ckeditor-sonata-media-bundle friendsofsymfony/ckeditor-bundle:1.2
 
 Register the bundle in your AppKernel:
 
@@ -16,10 +20,22 @@ public function registerBundles()
     return array(
         // ...
         new CoopTilleuls\Bundle\CKEditorSonataMediaBundle\CoopTilleulsCKEditorSonataMediaBundle(),
-        new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
+        new FOS\CKEditorBundle\FOSCKEditorBundle(),
         // ...
     );
 }
+```
+or 
+
+```php
+// config/bundles.php
+
+return [
+    // ...
+    CoopTilleuls\Bundle\CKEditorSonataMediaBundle\CoopTilleulsCKEditorSonataMediaBundle::class => ['all' => true],
+    FOS\CKEditorBundle\FOSCKEditorBundle::class => ['all' => true],
+    // ...
+];
 ```
 
 Install bundles:
@@ -28,12 +44,22 @@ Install bundles:
 $ composer update
 ```
 
-Configure IvoryCKEditorBundle to use the bundle as file browser:
+Add form theme to render the editor:
+
+Symfony 2/3: app/config/config.yml   
+Symfony 4: config/packages/twig.yaml
+```
+twig:
+    form_themes:
+        - '@FOSCKEditor/Form/ckeditor_widget.html.twig'
+```
+
+Configure FOSCKEditorBundle to use the bundle as file browser:
 
 ```yaml
 # app/config/config.yml
 
-ivory_ck_editor:
+fos_ck_editor:
     default_config: default
     configs:
         default:
@@ -74,7 +100,7 @@ Then update your ApplicationSonataMediaBundle:
 
 If you want to customize `MediaAdminController` you must extends `CoopTilleuls\Bundle\CKEditorSonataMediaBundle\Controller\MediaAdminController` in your bundle, and set parameter `sonata.media.admin.media.controller` to match your controller.
 
-## Usage without IvoryCKEditorBundle
+## Usage without FOSCKEditorBundle
 
 This bundle can be used with a custom install of CKEditor.
 Read the [file browser (uploader)](http://docs.cksource.com/CKEditor_3.x/Developers_Guide/File_Browser_(Uploader)) doc of CKEditor and the [architecture](architecture.md) of this bundle.

--- a/Resources/doc/install.md
+++ b/Resources/doc/install.md
@@ -72,7 +72,7 @@ Then update your ApplicationSonataMediaBundle:
     }
 ```
 
-If you want to customize `MediaAdminController` you must extends `CoopTilleuls\Bundle\CKEditorSonataMediaBundle\Controller\MediaAdminController` in your bundle.
+If you want to customize `MediaAdminController` you must extends `CoopTilleuls\Bundle\CKEditorSonataMediaBundle\Controller\MediaAdminController` in your bundle, and set parameter `sonata.media.admin.media.controller` to match your controller.
 
 ## Usage without IvoryCKEditorBundle
 

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -25,6 +25,20 @@ file that was distributed with this source code.
             <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'>
         {% endblock %}
 
+        <meta data-sonata-admin='{{ {
+            config: {
+                CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),
+                USE_SELECT2: sonata_admin.adminPool.getOption('use_select2'),
+                USE_ICHECK: sonata_admin.adminPool.getOption('use_icheck'),
+                USE_STICKYFORMS: sonata_admin.adminPool.getOption('use_stickyforms'),
+                DEBUG: sonata_admin.adminPool.getOption('js_debug'),
+            },
+            translations: {
+                CONFIRM_EXIT: 'confirm_exit'|trans({}, 'SonataAdminBundle'),
+            },
+        }|json_encode()|raw }}'
+        >
+
         {% block stylesheets %}
 
             {% for stylesheet in admin_pool.getOption('stylesheets', []) %}
@@ -34,16 +48,6 @@ file that was distributed with this source code.
         {% endblock %}
 
         {% block javascripts %}
-            <script>
-                window.SONATA_CONFIG = {
-                    CONFIRM_EXIT: {% if admin_pool is defined and admin_pool.getOption('confirm_exit') %}true{% else %}false{% endif %},
-                    USE_SELECT2: {% if admin_pool is defined and admin_pool.getOption('use_select2') %}true{% else %}false{% endif %},
-                    USE_ICHECK: {% if admin_pool is defined and admin_pool.getOption('use_icheck') %}true{% else %}false{% endif %}
-                };
-                window.SONATA_TRANSLATIONS = {
-                    CONFIRM_EXIT:  '{{ 'confirm_exit'|trans({}, 'SonataAdminBundle')|escape('js') }}'
-                };
-            </script>
 
             {% for javascript in admin_pool.getOption('javascripts', []) %}
             <script src="{{ asset(javascript) }}" type="text/javascript"></script>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -27,8 +27,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('browser', $config['templates']);
         $this->assertArrayHasKey('upload', $config['templates']);
 
-        $this->assertEquals('CoopTilleulsCKEditorSonataMediaBundle::layout.html.twig', $config['templates']['layout']);
-        $this->assertEquals('CoopTilleulsCKEditorSonataMediaBundle:MediaAdmin:browser.html.twig', $config['templates']['browser']);
-        $this->assertEquals('CoopTilleulsCKEditorSonataMediaBundle:MediaAdmin:upload.html.twig', $config['templates']['upload']);
+        $this->assertEquals('@CoopTilleulsCKEditorSonataMedia/layout.html.twig', $config['templates']['layout']);
+        $this->assertEquals('@CoopTilleulsCKEditorSonataMedia/MediaAdmin/browser.html.twig', $config['templates']['browser']);
+        $this->assertEquals('@CoopTilleulsCKEditorSonataMedia/MediaAdmin/upload.html.twig', $config['templates']['upload']);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "sonata-project/media-bundle": "~3.0",
-        "sonata-project/admin-bundle": "~3.1"
+        "sonata-project/admin-bundle": "~3.40"
     },
     "require-dev": {
         "symfony/phpunit-bridge":       "~2.7|~3.0",


### PR DESCRIPTION
This PR adds Compatibility for Symfony 4 and should fix issues #32 and #33

I'm not sure if this is the best solution, tell me if you have an other idea.
If you are ok with this solution I will update the install doc.

On an other note on sonata-project/admin-bundle 3.40 they have removed the inlined js used in the layout.html.twig, and replaced it with a meta attribute. This make the bundle not working with version > 3.40, do you want us to force to recent version, and update the layout.html.twig? And if yes, should I do it in this PR or in an other? 