### PR TITLE
remove the usage of `Bundle::getParent()`

### DIFF
--- a/CoopTilleulsCKEditorSonataMediaBundle.php
+++ b/CoopTilleulsCKEditorSonataMediaBundle.php
@@ -18,13 +18,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class CoopTilleulsCKEditorSonataMediaBundle extends Bundle
 {
-    /**
-     * Allows to extends the MediaAdmin controller.
-     *
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return 'SonataMediaBundle';
-    }
 }


### PR DESCRIPTION
This is deprecated in Symfony 3.4 and redundant in Symfony 4.x
